### PR TITLE
Add conda build recipe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,12 +13,21 @@ Riccati, Lyapunov and Sylvester equations.
 Prerequisite:
 -------------
 
-You will need Numpy, a fortran compiler such as gfortran and BLAS/LAPACK 
-libraries for building Slycot.
+Slycot depends on Numpy, and if you are installing a binary distribution, Numpy
+is the only prerequisite.
+
+If you are installing Slycot from source, you will need a fortran
+compiler such as gfortran, and BLAS/LAPACK libraries.
 
 On Debian derivates you can install all the above with a single command::
 
         sudo apt-get build-dep python-scipy
+
+On Mac, you will first need to install the `developer tools
+<https://developer.apple.com/xcode/>`_.  You can then install gfortran using
+`homebrew <http://brew.sh>`_ with::
+
+        brew install gcc
 
 On Windows, I suggest installing on top of the Python(x,y) distribution, and
 grabbing BLAS and LAPACK libraries from: 
@@ -45,6 +54,20 @@ On debian linux based systems you can install pip with the command::
 Pip can then be used to install Slycot wih the command::
 
         sudo pip install slycot
+
+There are some binary "wheels" available on PyPI, so if those versions match
+with your system, you may be able to avoid installing from source.
+
+Using conda
+~~~~~~~~~~~
+
+If you use `Anaconda or conda <http://continuum.io/downloads>`_ on Linux or Mac,
+it should be straighforward to install Slycot, without needing any compilers or
+other prerequisites.  Slycot is not included in the standard conda package
+repository, but there are packages available on http://binstar.org for Linux and
+Mac.  You can install with the following command::
+
+  conda install -c http://conda.binstar.org/cwrowley slycot
 
 
 From Source

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: slycot
+  version: "0.2.0"
+
+#source:
+#  fn: slycot-0.1.1.tar.gz
+#  url: https://pypi.python.org/packages/source/s/slycot/slycot-0.1.1.tar.gz
+#  md5: 125aac075d539d36004cc3baf3626bc7
+
+build:
+  number: 1
+
+  script:
+    - cd $RECIPE_DIR/..
+    - $PYTHON setup.py install
+
+requirements:
+  build:
+    - python
+    - numpy
+    - lapack
+
+  run:
+    - python
+    - numpy
+    - lapack
+
+test:
+  imports:
+    - slycot
+
+about:
+  home: https://pypi.python.org/pypi/slycot
+  license:  BSD License
+  summary: 'A wrapper for the SLICOT control and systems library'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
This PR adds a recipe for building a conda package, and updates the README with instructions on how to install using conda, and on a Mac.

The conda package can be built with
```
conda build conda-recipe
```
but users do not need to do this.  (They can just use the conda package already built, which is on binstar.)  Note that the conda recipe lists lapack as a prerequisite, and lapack is not among the standard list of packages provided by conda, but I have a version on http://binstar.org/cwrowley that can be used.