### PR TITLE
Sb10ad fix synthesis.pyf

### DIFF
--- a/slycot/src/synthesis.pyf
+++ b/slycot/src/synthesis.pyf
@@ -410,13 +410,13 @@ subroutine sb10ad(job,n,m,np,ncon,nmeas,gamma,a,lda,b,ldb,c,ldc,d,ldd,ak,ldak,bk
     double precision intent(out), dimension(ncon,nmeas), depend(ncon,nmeas) :: dk
     integer intent(hide), depend(dk) :: lddk=shape(dk,0)
     double precision intent(out), dimension(2*n,2*n), depend(n) :: ac
-    integer intent(hide), depend(ac) :: ldak=shape(ac,0)
+    integer intent(hide), depend(ac) :: ldac=shape(ac,0)
     double precision intent(out), dimension(2*n,m-ncon), depend(n,m,ncon) :: bc
-    integer intent(hide), depend(bc) :: ldbk=shape(bc,0)
+    integer intent(hide), depend(bc) :: ldbc=shape(bc,0)
     double precision intent(out), dimension(np-nmeas,2*n), depend(np,nmeas,n) :: cc
-    integer intent(hide), depend(cc) :: ldck=shape(cc,0)
+    integer intent(hide), depend(cc) :: ldcc=shape(cc,0)
     double precision intent(out), dimension(np-nmeas,m-ncon), depend(np,nmeas,m,ncon) :: dc
-    integer intent(hide), depend(dc) :: lddk=shape(dc,0)
+    integer intent(hide), depend(dc) :: lddc=shape(dc,0)
     double precision intent(out), dimension(4) :: rcond
     double precision optional :: gtol=0.0
     double precision optional :: actol=0.0

--- a/slycot/tests/test.py
+++ b/slycot/tests/test.py
@@ -15,3 +15,36 @@ class Test(unittest.TestCase):
         from scipy import matrix
         a = matrix("-2 0.5;-1.6 -5")
         Ar, Vr, Yr, VALRr, VALDr = math.mb05md(a, 0.1)
+
+    def test_sb02ad(self):
+        "Test sb10ad, Hinf synthesis"
+        import numpy as np
+        a = np.array([[-1]])
+        b = np.array([[1, 1]])
+        c = np.array([[1], [1]])
+        d = np.array([[0, 1], [1, 0]])
+
+        n = 1
+        m = 2
+        np_ = 2
+        ncon = 1
+        nmeas = 1
+        gamma = 10
+
+        gamma_est, Ak, Bk, Ck, Dk, Ac, Bc, Cc, Dc, rcond = synthesis.sb10ad(
+            n, m, np_, ncon, nmeas, gamma, a, b, c, d)
+        # from Octave, which also uses SB10AD:
+        #   a= -1; b1= 1; b2= 1; c1= 1; c2= 1; d11= 0; d12= 1; d21= 1; d22= 0;
+        #   g = ss(a,[b1,b2],[c1;c2],[d11,d12;d21,d22]);
+        #   [k,cl] = hinfsyn(g,1,1);
+        # k.a is Ak, cl.a is Ac
+        # gamma values don't match; not sure that's critical
+        # this is a bit fragile
+        # a simpler, more robust check might be to check stability of Ac
+        self.assertEqual(Ak.shape, (1, 1))
+        self.assertAlmostEqual(Ak[0][0], -3)
+        self.assertEqual(Ac.shape, (2, 2))
+        self.assertAlmostEqual(Ac[0][0], -1)
+        self.assertAlmostEqual(Ac[0][1], -1)
+        self.assertAlmostEqual(Ac[1][0], 1)
+        self.assertAlmostEqual(Ac[1][1], -3)


### PR DESCRIPTION
The sb10ad entry in synthesis.pyf did not infer ldac, ldab, ldac, ldad values from ac, bc, cc, dc, but instead looked like

```
    integer intent(hide), depend(ak) :: ldak=shape(ak,0)
    [... lines omitted]
    integer intent(hide), depend(ac) :: ldak=shape(ac,0)
```

The last line should be ldac, not ldak; the same bug is present for ldbc, etc.

I'm don't know enough about f2py to know if it should have raised a warning or error in this case.

Added a simple test for this case.
