### PR TITLE
Fix format bug in error strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ If the build fails and you are on a 64bit OS you may want to try::
 For Windows, and using Python(x,y), specify that you are using the
 mingw compiler. Create a file
 
-C:\Python27\Lib\distutils\distutils.cfg
+C:\\Python27\\Lib\\distutils\\distutils.cfg
 
 with as contents::
 

--- a/slycot/synthesis.py
+++ b/slycot/synthesis.py
@@ -938,7 +938,7 @@ def sb04md(n,m,A,B,C,ldwork=None):
         raise e
     elif out[-1] > m:
         error_text = """a singular matrix was encountered whilst solving
-for the %i-th column of matrix X.""" % out[-1]-m
+for the %i-th column of matrix X.""" % (out[-1]-m)
         e = ValueError(error_text)
         e.info = out[-1]
         raise e
@@ -1003,7 +1003,7 @@ def sb04qd(n,m,A,B,C,ldwork=None):
         raise e
     elif out[-1] > m:
         error_text = """a singular matrix was encountered whilst solving
-for the %i-th column of matrix X.""" % out[-1]-m
+for the %i-th column of matrix X.""" % (out[-1]-m)
         e = ValueError(error_text)
         e.info = out[-1]
         raise e


### PR DESCRIPTION
Pretty straightforward operator precedence error, resulting in a TypeError.

    >>> s = """%i""" % 2-1
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: unsupported operand type(s) for -: 'str' and 'int'

Also fixed a simple os.path.sep issue with the README while I was in there. :)